### PR TITLE
Handle synchronous Spond client responses

### DIFF
--- a/api/v2/utils/creators.py
+++ b/api/v2/utils/creators.py
@@ -1,10 +1,15 @@
+import inspect
 from typing import Dict, Any
 
 
 async def create_member_dict(s, group_id: str) -> Dict[str, str]:
     """Return a mapping of member id to full name for a given Spond group."""
 
-    group: Dict[str, Any] = await s.get_group(group_id)
+    group_result = s.get_group(group_id)
+    if inspect.isawaitable(group_result):
+        group: Dict[str, Any] = await group_result
+    else:
+        group = group_result
     members: Dict[str, str] = {}
 
     for member in group.get("members", []):

--- a/api/v2/utils/extractors.py
+++ b/api/v2/utils/extractors.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import inspect
 from typing import Any, Dict, Iterable, List
 
 
@@ -10,7 +11,12 @@ ISO_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 async def extract_future_events(s, group_id: str) -> List[Dict[str, Any]]:
     """Return events ending within the last 48 hours or in the future."""
 
-    events: Iterable[Dict[str, Any]] = await s.get_events([group_id])
+    events_result = s.get_events([group_id])
+    events: Iterable[Dict[str, Any]]
+    if inspect.isawaitable(events_result):
+        events = await events_result
+    else:
+        events = events_result
     fut_events: List[Dict[str, Any]] = []
 
     now = datetime.datetime.now(datetime.timezone.utc)
@@ -41,7 +47,12 @@ async def extract_events_in_range(
 ) -> List[Dict[str, Any]]:
     """Return events that end inside the inclusive ``start_time``/``end_time`` window."""
 
-    events: Iterable[Dict[str, Any]] = await s.get_events([group_id])
+    events_result = s.get_events([group_id])
+    events: Iterable[Dict[str, Any]]
+    if inspect.isawaitable(events_result):
+        events = await events_result
+    else:
+        events = events_result
     in_range_events: List[Dict[str, Any]] = []
 
     for event in events:


### PR DESCRIPTION
## Summary
- make the Spond utilities tolerate clients that return data synchronously
- avoid raising internal server errors when fetching events or groups from Spond

## Testing
- python -m compileall api/v2

------
https://chatgpt.com/codex/tasks/task_e_68d6f29e684c832fbf5c7096f8f192ef