### PR TITLE
Handle runtime storage and close Spond client session

### DIFF
--- a/api/v2/utils/spond.py
+++ b/api/v2/utils/spond.py
@@ -33,11 +33,16 @@ async def get_next_training_attendees() -> List[str]:
     now = datetime.datetime.now(datetime.timezone.utc)
     end = now + datetime.timedelta(days=6)
 
-    future_events = await extract_events_in_range(now, end, client, group_id)
-    future_trainings = filter_events(future_events, "heading", "Trening")
+    try:
+        future_events = await extract_events_in_range(now, end, client, group_id)
+        future_trainings = filter_events(future_events, "heading", "Trening")
 
-    if not future_trainings:
-        raise HTTPException(status_code=404, detail="No upcoming training found in Spond.")
+        if not future_trainings:
+            raise HTTPException(
+                status_code=404, detail="No upcoming training found in Spond."
+            )
 
-    members = await create_member_dict(client, group_id)
-    return extract_attendees_name(future_trainings[0], members)
+        members = await create_member_dict(client, group_id)
+        return extract_attendees_name(future_trainings[0], members)
+    finally:
+        await client.clientsession.close()


### PR DESCRIPTION
## Summary
- write attendee and group JSON files to a configurable runtime directory that falls back to seeded data when unavailable
- close the Spond API client session after fetching attendees to prevent unclosed session warnings

## Testing
- python -m compileall api/v2

------
https://chatgpt.com/codex/tasks/task_e_68d6f82bfae4832f95e0f74a0e87b81b