### PR TITLE
Switch API storage to in-memory runtime state

### DIFF
--- a/api/v2/data_store.py
+++ b/api/v2/data_store.py
@@ -1,0 +1,81 @@
+"""In-memory runtime store for attendees and groups."""
+from __future__ import annotations
+
+import copy
+import json
+from asyncio import Lock
+from pathlib import Path
+from typing import Any, List, Optional
+
+from fastapi import HTTPException
+
+
+class InMemoryDataStore:
+    """Persist attendees and groups in memory with seed fallbacks."""
+
+    def __init__(self, attendees_seed: Path, groups_seed: Path) -> None:
+        self._lock = Lock()
+        self._attendees_seed = attendees_seed
+        self._groups_seed = groups_seed
+        self._attendees: Optional[List[Any]] = None
+        self._groups: Optional[List[Any]] = None
+
+    async def get_attendees(self) -> List[Any]:
+        """Return the current attendees, seeding from disk on first use."""
+
+        async with self._lock:
+            if self._attendees is None:
+                self._attendees = self._load_seed(self._attendees_seed, "Attendees")
+            return copy.deepcopy(self._attendees)
+
+    async def replace_attendees(self, attendees: List[Any]) -> None:
+        """Replace the stored attendees with the provided list."""
+
+        if not isinstance(attendees, list):
+            raise HTTPException(
+                status_code=500, detail="Attendees payload must be a JSON array (list)."
+            )
+        async with self._lock:
+            self._attendees = copy.deepcopy(attendees)
+
+    async def get_groups(self) -> List[Any]:
+        """Return the current groups, seeding from disk on first use."""
+
+        async with self._lock:
+            if self._groups is None:
+                self._groups = self._load_seed(self._groups_seed, "Groups")
+            return copy.deepcopy(self._groups)
+
+    async def replace_groups(self, groups: List[Any]) -> None:
+        """Replace the stored groups with the provided list."""
+
+        if not isinstance(groups, list):
+            raise HTTPException(
+                status_code=500, detail="Groups payload must be a JSON array (list)."
+            )
+        async with self._lock:
+            self._groups = copy.deepcopy(groups)
+
+    def _load_seed(self, path: Path, kind: str) -> List[Any]:
+        if not path.exists():
+            raise HTTPException(
+                status_code=500, detail=f"{kind} seed file not found: {path}"
+            )
+        try:
+            with path.open("r", encoding="utf-8") as handle:
+                data = json.load(handle)
+        except json.JSONDecodeError as exc:
+            raise HTTPException(
+                status_code=500, detail=f"Invalid JSON in {path.name}: {exc}"
+            ) from exc
+
+        if not isinstance(data, list):
+            raise HTTPException(
+                status_code=500,
+                detail=f"{path.name} seed must contain a JSON array (list).",
+            )
+        return data
+
+
+MODULE_DIR = Path(__file__).resolve().parent
+store = InMemoryDataStore(MODULE_DIR / "attendees.json", MODULE_DIR / "groups.json")

--- a/api/v2/main.py
+++ b/api/v2/main.py
@@ -1,29 +1,18 @@
 import logging
-from fastapi import FastAPI, Query, HTTPException
-from fastapi.responses import JSONResponse
-from fastapi.middleware.cors import CORSMiddleware
-from asyncio import Lock
-from pydantic import BaseModel, ValidationError
-from typing import Any, List, Optional, Tuple
-import json
-import os
 import random
-from pathlib import Path
+from typing import Any, List, Optional, Tuple
 
+from fastapi import FastAPI, HTTPException, Query
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, ValidationError
+
+from api.v2.data_store import store as data_store
 from api.v2.utils.spond import get_next_training_attendees
 
 logging.basicConfig(level=logging.INFO)
 
 app = FastAPI()
-
-MODULE_DIR = Path(__file__).resolve().parent
-RUNTIME_DATA_DIR = Path(os.getenv("BSI_RUNTIME_DATA_DIR", "/tmp/bsi-golf-api"))
-
-ATTENDEES_PATH = RUNTIME_DATA_DIR / "attendees.json"
-GROUPS_PATH = RUNTIME_DATA_DIR / "groups.json"
-
-ATTENDEES_SEED_PATH = MODULE_DIR / "attendees.json"
-GROUPS_SEED_PATH = MODULE_DIR / "groups.json"
 
 # Restrict access to the production frontend
 app.add_middleware(
@@ -33,8 +22,6 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-
-lock = Lock()
 
 
 # --------------------------
@@ -59,53 +46,6 @@ class ShuffleResponse(BaseModel):
 # --------------------------
 # Helpers
 # --------------------------
-async def load_json_array(
-    path: Path, kind: str, *, seed_path: Optional[Path] = None
-) -> List[Any]:
-    candidates = [path]
-    if seed_path and seed_path not in candidates:
-        candidates.append(seed_path)
-
-    selected_path: Optional[Path] = None
-    for candidate in candidates:
-        candidate_path = Path(candidate)
-        if candidate_path.exists():
-            selected_path = candidate_path
-            break
-
-    if selected_path is None:
-        locations = ", ".join(str(Path(c)) for c in candidates)
-        raise HTTPException(
-            status_code=500,
-            detail=f"{kind} file not found in any of: {locations}",
-        )
-    try:
-        async with lock:
-            with selected_path.open("r", encoding="utf-8") as f:
-                data = json.load(f)
-        if not isinstance(data, list):
-            raise HTTPException(
-                status_code=500,
-                detail=f"{os.path.basename(
-                    selected_path)} must be a JSON array (list).",
-            )
-        return data
-    except json.JSONDecodeError as e:
-        raise HTTPException(
-            status_code=500,
-            detail=f"Invalid JSON in {os.path.basename(selected_path)}: {e}"
-        )
-
-
-async def save_json(path: Path, payload: Any) -> None:
-    async with lock:
-        # Ensure dir exists
-        path = Path(path)
-        path.parent.mkdir(parents=True, exist_ok=True)
-        with path.open("w", encoding="utf-8") as f:
-            json.dump(payload, f, ensure_ascii=False, indent=2)
-
-
 def shuffle_into_groups(
     attendees: List[Any], sim_count: int
 ) -> List[List[Any]]:
@@ -160,7 +100,7 @@ def find_member_position(
 @app.get("/attendeesFromSpond")
 async def get_attendees_from_spond():
     attendees = await get_next_training_attendees()
-    await save_json(ATTENDEES_PATH, attendees)
+    await data_store.replace_attendees(attendees)
     return JSONResponse(
         content=attendees,
         headers={"Cache-Control": "no-store, no-cache, must-revalidate"},
@@ -169,10 +109,8 @@ async def get_attendees_from_spond():
 
 @app.get("/attendees/")
 async def get_attendees():
-    """Reads the attendees from a file and returns them."""
-    attendees = await load_json_array(
-        ATTENDEES_PATH, "Attendees", seed_path=ATTENDEES_SEED_PATH
-    )
+    """Return the current attendees from the in-memory store."""
+    attendees = await data_store.get_attendees()
     return JSONResponse(
         content=attendees,
         headers={"Cache-Control": "no-store, no-cache, must-revalidate"},
@@ -186,9 +124,7 @@ async def post_shuffle_attendees(
     ),
 ):
     # Load attendees
-    attendees = await load_json_array(
-        ATTENDEES_PATH, "Attendees", seed_path=ATTENDEES_SEED_PATH
-    )
+    attendees = await data_store.get_attendees()
 
     # Compute groups
     groups_raw = shuffle_into_groups(attendees, sim_count)
@@ -196,9 +132,9 @@ async def post_shuffle_attendees(
         Group(group_id=i + 1, members=members) for i, members in enumerate(groups_raw)
     ]
 
-    # Persist groups to groups.json (store plain JSON, same structure as response.groups)
+    # Persist groups in the in-memory store (same structure as response.groups)
     groups_payload = [g.model_dump() for g in groups_model]
-    await save_json(GROUPS_PATH, groups_payload)
+    await data_store.replace_groups(groups_payload)
 
     # Return the same groups in a typed response
     return ShuffleResponse(
@@ -210,9 +146,7 @@ async def post_shuffle_attendees(
 async def post_swap_attendees(payload: SwapRequest) -> ShuffleResponse:
     """Swap two attendees between groups and return the updated grouping."""
 
-    groups_data = await load_json_array(
-        GROUPS_PATH, "Groups", seed_path=GROUPS_SEED_PATH
-    )
+    groups_data = await data_store.get_groups()
     if not groups_data:
         raise HTTPException(
             status_code=404, detail="No groups available to modify."
@@ -248,7 +182,7 @@ async def post_swap_attendees(payload: SwapRequest) -> ShuffleResponse:
             detail="Stored group data is invalid after swap operation.",
         ) from exc
 
-    await save_json(GROUPS_PATH, [group.model_dump() for group in groups_model])
+    await data_store.replace_groups([group.model_dump() for group in groups_model])
 
     total_attendees = sum(len(group.members) for group in groups_model)
     return ShuffleResponse(
@@ -260,11 +194,9 @@ async def post_swap_attendees(payload: SwapRequest) -> ShuffleResponse:
 
 @app.get("/groups/", response_model=ShuffleResponse)
 async def get_groups() -> JSONResponse:
-    """Reads the most recently saved groups from groups.json."""
+    """Return the most recently saved groups from the in-memory store."""
 
-    groups = await load_json_array(
-        GROUPS_PATH, "Groups", seed_path=GROUPS_SEED_PATH
-    )
+    groups = await data_store.get_groups()
 
     try:
         groups_model = [Group(**group) for group in groups]


### PR DESCRIPTION
## Summary
- add an in-memory data store seeded from the bundled JSON fixtures
- update the v2 endpoints to read and persist attendees and groups through the in-memory store

## Testing
- python -m compileall api/v2

------
https://chatgpt.com/codex/tasks/task_e_68d7073d4b78832f901bd6e8e55863b2