### PR TITLE
Switch data store to PostgreSQL

### DIFF
--- a/api/v2/data_store.py
+++ b/api/v2/data_store.py
@@ -1,85 +1,149 @@
-"""In-memory runtime store for attendees and groups."""
+"""PostgreSQL-backed runtime store for attendees and groups."""
 from __future__ import annotations
 
 import copy
-import json
+import os
 from asyncio import Lock
-from pathlib import Path
-from typing import Any, List, Optional
+from typing import Any, List
 
+import psycopg
 from fastapi import HTTPException
+from psycopg.rows import dict_row
+from psycopg.types.json import Json
+from psycopg_pool import AsyncConnectionPool
 
 
-class InMemoryDataStore:
-    """Persist attendees and groups in memory with seed fallbacks."""
+class PostgresDataStore:
+    """Persist attendees and groups in PostgreSQL as JSON payloads."""
 
-    def __init__(self, attendees_seed: Path, groups_seed: Path | None = None) -> None:
-        self._lock = Lock()
-        self._attendees_seed = attendees_seed
-        self._groups_seed = groups_seed
-        self._attendees: Optional[List[Any]] = None
-        self._groups: Optional[List[Any]] = None
+    TABLE_NAME = "api_state"
+    ATTENDEES_KEY = "attendees"
+    GROUPS_KEY = "groups"
+
+    def __init__(self, dsn: str) -> None:
+        self._dsn = dsn
+        self._pool: AsyncConnectionPool | None = None
+        self._pool_lock = Lock()
 
     async def get_attendees(self) -> List[Any]:
-        """Return the current attendees, seeding from disk on first use."""
+        """Return the current attendees stored in the database."""
 
-        async with self._lock:
-            if self._attendees is None:
-                self._attendees = self._load_seed(self._attendees_seed, "Attendees")
-            return copy.deepcopy(self._attendees)
+        data = await self._fetch_list(self.ATTENDEES_KEY)
+        return copy.deepcopy(data)
 
     async def replace_attendees(self, attendees: List[Any]) -> None:
         """Replace the stored attendees with the provided list."""
 
-        if not isinstance(attendees, list):
-            raise HTTPException(
-                status_code=500, detail="Attendees payload must be a JSON array (list)."
-            )
-        async with self._lock:
-            self._attendees = copy.deepcopy(attendees)
+        await self._store_list(self.ATTENDEES_KEY, attendees)
 
     async def get_groups(self) -> List[Any]:
-        """Return the current groups, seeding from disk on first use."""
+        """Return the current simulator groups stored in the database."""
 
-        async with self._lock:
-            if self._groups is None:
-                self._groups = (
-                    self._load_seed(self._groups_seed, "Groups")
-                    if self._groups_seed is not None
-                    else []
-                )
-            return copy.deepcopy(self._groups)
+        data = await self._fetch_list(self.GROUPS_KEY)
+        return copy.deepcopy(data)
 
     async def replace_groups(self, groups: List[Any]) -> None:
         """Replace the stored groups with the provided list."""
 
-        if not isinstance(groups, list):
-            raise HTTPException(
-                status_code=500, detail="Groups payload must be a JSON array (list)."
-            )
-        async with self._lock:
-            self._groups = copy.deepcopy(groups)
+        await self._store_list(self.GROUPS_KEY, groups)
 
-    def _load_seed(self, path: Path, kind: str) -> List[Any]:
-        if not path.exists():
-            raise HTTPException(
-                status_code=500, detail=f"{kind} seed file not found: {path}"
-            )
-        try:
-            with path.open("r", encoding="utf-8") as handle:
-                data = json.load(handle)
-        except json.JSONDecodeError as exc:
-            raise HTTPException(
-                status_code=500, detail=f"Invalid JSON in {path.name}: {exc}"
-            ) from exc
-
-        if not isinstance(data, list):
+    async def _store_list(self, key: str, payload: List[Any]) -> None:
+        if not isinstance(payload, list):
             raise HTTPException(
                 status_code=500,
-                detail=f"{path.name} seed must contain a JSON array (list).",
+                detail=f"{key.capitalize()} payload must be a JSON array (list).",
             )
-        return data
+
+        pool = await self._ensure_pool()
+
+        try:
+            async with pool.connection() as conn:
+                async with conn.cursor() as cur:
+                    await cur.execute(
+                        f"""
+                        INSERT INTO {self.TABLE_NAME} (key, value)
+                        VALUES (%s, %s)
+                        ON CONFLICT (key) DO UPDATE
+                        SET value = EXCLUDED.value,
+                            updated_at = NOW()
+                        """,
+                        (key, Json(copy.deepcopy(payload))),
+                    )
+        except psycopg.Error as exc:  # pragma: no cover - surface as HTTP error
+            raise HTTPException(
+                status_code=500, detail="Database error while saving data."
+            ) from exc
+
+    async def _fetch_list(self, key: str) -> List[Any]:
+        pool = await self._ensure_pool()
+
+        try:
+            async with pool.connection() as conn:
+                async with conn.cursor(row_factory=dict_row) as cur:
+                    await cur.execute(
+                        f"SELECT value FROM {self.TABLE_NAME} WHERE key = %s", (key,)
+                    )
+                    row = await cur.fetchone()
+        except psycopg.Error as exc:  # pragma: no cover - surface as HTTP error
+            raise HTTPException(
+                status_code=500, detail="Database error while loading data."
+            ) from exc
+
+        value = row["value"] if row is not None else []
+        if value is None:
+            value = []
+        if not isinstance(value, list):
+            raise HTTPException(
+                status_code=500,
+                detail=f"Stored {key} data must be a JSON array (list).",
+            )
+        return value
+
+    async def _ensure_pool(self) -> AsyncConnectionPool:
+        if self._pool is None:
+            async with self._pool_lock:
+                if self._pool is None:
+                    try:
+                        self._pool = AsyncConnectionPool(
+                            self._dsn,
+                            min_size=1,
+                            max_size=5,
+                            kwargs={"autocommit": True},
+                        )
+                        await self._pool.open()
+                        await self._initialise_schema()
+                    except psycopg.Error as exc:  # pragma: no cover - init failure
+                        raise HTTPException(
+                            status_code=500,
+                            detail="Could not connect to the database.",
+                        ) from exc
+        assert self._pool is not None  # for type checkers
+        return self._pool
+
+    async def _initialise_schema(self) -> None:
+        assert self._pool is not None
+        try:
+            async with self._pool.connection() as conn:
+                async with conn.cursor() as cur:
+                    await cur.execute(
+                        f"""
+                        CREATE TABLE IF NOT EXISTS {self.TABLE_NAME} (
+                            key TEXT PRIMARY KEY,
+                            value JSONB NOT NULL,
+                            updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+                        )
+                        """
+                    )
+        except psycopg.Error as exc:  # pragma: no cover - init failure
+            raise HTTPException(
+                status_code=500,
+                detail="Failed to initialise database schema.",
+            ) from exc
 
 
-MODULE_DIR = Path(__file__).resolve().parent
-store = InMemoryDataStore(MODULE_DIR / "attendees.json")
+DATABASE_URL = os.getenv(
+    "DATABASE_URL",
+    "postgresql://neondb_owner:npg_j5tlyPDaX4VF@ep-cold-sky-ab325omy-pooler.eu-west-2.aws.neon.tech/neondb?sslmode=require&channel_binding=require",
+)
+
+store = PostgresDataStore(DATABASE_URL)

--- a/api/v2/main.py
+++ b/api/v2/main.py
@@ -109,7 +109,7 @@ async def get_attendees_from_spond():
 
 @app.get("/attendees/")
 async def get_attendees():
-    """Return the current attendees from the in-memory store."""
+    """Return the current attendees from the PostgreSQL store."""
     attendees = await data_store.get_attendees()
     return JSONResponse(
         content=attendees,
@@ -132,7 +132,7 @@ async def post_shuffle_attendees(
         Group(group_id=i + 1, members=members) for i, members in enumerate(groups_raw)
     ]
 
-    # Persist groups in the in-memory store (same structure as response.groups)
+    # Persist groups in the PostgreSQL store (same structure as response.groups)
     groups_payload = [g.model_dump() for g in groups_model]
     await data_store.replace_groups(groups_payload)
 
@@ -194,7 +194,7 @@ async def post_swap_attendees(payload: SwapRequest) -> ShuffleResponse:
 
 @app.get("/groups/", response_model=ShuffleResponse)
 async def get_groups() -> JSONResponse:
-    """Return the most recently saved groups from the in-memory store."""
+    """Return the most recently saved groups from the PostgreSQL store."""
 
     groups = await data_store.get_groups()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ openpyxl
 starlette
 pydantic
 httpx
+psycopg[binary,pool]


### PR DESCRIPTION
## Summary
- replace the in-memory data store with a PostgreSQL-backed implementation using psycopg
- update API documentation strings to reflect the new persistence layer
- add the psycopg dependency to requirements

## Testing
- python -m compileall api/v2

------
https://chatgpt.com/codex/tasks/task_e_68d70b32054c832f96e2fc86427b9278