### PR TITLE
Add endpoints for retrieving member rosters

### DIFF
--- a/api/v2/main.py
+++ b/api/v2/main.py
@@ -8,7 +8,11 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ValidationError
 
 from api.v2.data_store import store as data_store
-from api.v2.utils.spond import get_next_training_attendees
+from api.v2.utils.spond import (
+    get_all_members,
+    get_members_not_attending_next_event,
+    get_next_training_attendees,
+)
 
 logging.basicConfig(level=logging.INFO)
 
@@ -113,6 +117,28 @@ async def get_attendees():
     attendees = await data_store.get_attendees()
     return JSONResponse(
         content=attendees,
+        headers={"Cache-Control": "no-store, no-cache, must-revalidate"},
+    )
+
+
+@app.get("/members/")
+async def get_members():
+    """Return every member registered in the Spond group."""
+
+    members = await get_all_members()
+    return JSONResponse(
+        content=members,
+        headers={"Cache-Control": "no-store, no-cache, must-revalidate"},
+    )
+
+
+@app.get("/members/notAttendingNextEvent")
+async def get_members_not_attending():
+    """Return members who are not attending the next upcoming training event."""
+
+    members = await get_members_not_attending_next_event()
+    return JSONResponse(
+        content=members,
         headers={"Cache-Control": "no-store, no-cache, must-revalidate"},
     )
 

--- a/api/v2/utils/spond.py
+++ b/api/v2/utils/spond.py
@@ -6,7 +6,11 @@ from fastapi import HTTPException
 from spond import spond
 
 from api.v2.utils.creators import create_member_dict
-from api.v2.utils.extractors import extract_attendees_name, extract_events_in_range
+from api.v2.utils.extractors import (
+    extract_attendees_id,
+    extract_attendees_name,
+    extract_events_in_range,
+)
 from api.v2.utils.filters import filter_events
 
 group_id = "8D0C460783EB466B98AF0C3980163A34"
@@ -44,5 +48,46 @@ async def get_next_training_attendees() -> List[str]:
 
         members = await create_member_dict(client, group_id)
         return extract_attendees_name(future_trainings[0], members)
+    finally:
+        await client.clientsession.close()
+
+
+async def get_all_members() -> List[str]:
+    """Return the full member list for the configured Spond group."""
+
+    username, password = _get_credentials()
+    client = spond.Spond(username=username, password=password)
+
+    try:
+        members = await create_member_dict(client, group_id)
+        return sorted(members.values())
+    finally:
+        await client.clientsession.close()
+
+
+async def get_members_not_attending_next_event() -> List[str]:
+    """Return members who are not attending the next upcoming training event."""
+
+    username, password = _get_credentials()
+    client = spond.Spond(username=username, password=password)
+    now = datetime.datetime.now(datetime.timezone.utc)
+    end = now + datetime.timedelta(days=6)
+
+    try:
+        future_events = await extract_events_in_range(now, end, client, group_id)
+        future_trainings = filter_events(future_events, "heading", "Trening")
+
+        if not future_trainings:
+            raise HTTPException(
+                status_code=404, detail="No upcoming training found in Spond."
+            )
+
+        members = await create_member_dict(client, group_id)
+        attendees_ids = set(extract_attendees_id(future_trainings[0]))
+
+        non_attending = [
+            name for member_id, name in members.items() if member_id not in attendees_ids
+        ]
+        return sorted(non_attending)
     finally:
         await client.clientsession.close()


### PR DESCRIPTION
## Summary
- add Spond utility helpers to list all group members and identify absentees for the next event
- expose new API endpoints that return the full member roster and the non-attending subset

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d710c9ba58832fba8e18c64d1ce393